### PR TITLE
Small fix to allow the form to be visible if the windows toolbar is at the top of the screen.

### DIFF
--- a/AppHarbor.Lookout/AppHarborForm.cs
+++ b/AppHarbor.Lookout/AppHarborForm.cs
@@ -342,6 +342,8 @@ Updated at: {1}",
         {            
             var cursorPosn = new Point(Cursor.Position.X, Cursor.Position.Y);            
             var mouseLocation = new Point(cursorPosn.X - Width, cursorPosn.Y - Height - 15);
+            if (mouseLocation.Y < 15)
+                mouseLocation.Y = 15;
             StartPosition = FormStartPosition.Manual;
             Location = mouseLocation;
             _allowVisible = true;


### PR DESCRIPTION
The form goes out the edge of the screen if the tray icon is at the top of the screen, this fix just sets the form.Location.Y to 15 if it detects that it would go offscreen.
- Federico
